### PR TITLE
Added browse_by_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ odoo.get('res.partner', params, function (err, partners) {
 //   { id: 4, name: 'Public user' },
 //   { id: 5, name: 'Demo User' }
 // ]
-});
+}); //get
 
 
 // Search & Get products in one RPC call
@@ -67,7 +67,29 @@ odoo.search_read('product.product', params, function (err, products) {
 //   { list_price: 62, id: 39, name: 'Headset standard' }
 // ]
 
-});
+}); //search_read
+
+
+// Browse products by ID
+// Not a direct implementation of Odoo RPC 'browse' but rather a workaround based on 'search_read'
+// https://www.odoo.com/documentation/8.0/reference/orm.html#openerp.models.Model.browse
+var params = {
+  fields: [ 'name', 'list_price'],
+  limit: 5,
+  offset: 0,  
+}; //params
+odoo.browse_by_id('product.product', params, function (err, products) {
+  if (err) { return console.log(err); }
+
+  console.log(products);
+// [
+//   { list_price: 4.49, id: 1180, name: 'Fruit Cup' },
+//   { list_price: 0, id: 1139, name: 'Orange Crush' },
+//   { list_price: 1.59, id: 1062, name: 'Blueberry muffin' },
+//   { list_price: 1.35, id: 1381, name: 'Otis Harvest Bran' }
+// ]
+}); //browse_by_id
+
 
 ```
 
@@ -77,6 +99,7 @@ odoo.search_read('product.product', params, function (err, products) {
 * odoo.get(model, id, callback)
 * odoo.search(model, params, callback)
 * odoo.search_read(model, params, callback)
+* odoo.browse_by_id(model, params, callback)
 * odoo.create(model, params, callback)
 * odoo.update(model, id, params, callback)
 * odoo.delete(model, id, callback)

--- a/lib/index.js
+++ b/lib/index.js
@@ -123,7 +123,17 @@ Odoo.prototype.get = function (model, params, callback) {
       fields: params.fields,
     },
   }, callback);
-};
+}; //get
+
+
+// Browse records by ID
+// Not a direct implementation of Odoo RPC 'browse' but rather a workaround based on 'search_read'
+// https://www.odoo.com/documentation/8.0/reference/orm.html#openerp.models.Model.browse
+Odoo.prototype.browse_by_id = function(model, params, callback) {
+  params.domain = [['id', '>', '0' ]];  // assumes all records IDs are > 0
+  this.search_read(model, params, callback);
+}; //browse
+
 
 // Create record
 Odoo.prototype.create = function (model, params, callback) {


### PR DESCRIPTION
Mimics Odoo's 'browse' RPC call.

Parameters similar to 'search_read' with the exception that the 'domain' parameter is hard-coded to search by ID.

Closes #3 .