### PR TITLE
Pass context to get method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -121,6 +121,7 @@ Odoo.prototype.get = function (model, params, callback) {
       params.ids,
     ],
     kwargs: {
+      context: this.context,
       fields: params.fields,
     },
   }, callback);


### PR DESCRIPTION
otherwise things like language get ignored when using get. Pretty annoying